### PR TITLE
[BE][Endpoint] Add New Endpoint for Get Games Details

### DIFF
--- a/src/domains/games/controller.js
+++ b/src/domains/games/controller.js
@@ -20,4 +20,10 @@ module.exports = {
 
     res.json(response);
   },
+  getDetails: async (req, res) => {
+    const game = await gameRepository.getDetails(req.params.id);
+    const response = new SuccessResponse('Success Get Game Details', game);
+
+    res.json(response);
+  },
 };

--- a/src/domains/games/repository.js
+++ b/src/domains/games/repository.js
@@ -21,4 +21,13 @@ module.exports = {
       [param]: updatedGame[param],
     };
   },
+  getDetails: async (id) => {
+    const game = await Game.findOne({ where: { id: id } });
+
+    if (!game) {
+      throw new AppError('Game Not Found', 404);
+    }
+
+    return game;
+  },
 };

--- a/src/domains/games/router.js
+++ b/src/domains/games/router.js
@@ -16,6 +16,7 @@ const routes = {
     validation(gameValidator.paramsId),
     gameController.addPlayCount,
   ],
+  'GET: /:id': [validation(gameValidator.paramsId), gameController.getDetails],
 };
 
 buildRoutes(gamesRouter, routes);


### PR DESCRIPTION
## [BE][Endpoint] Add New Endpoint for Get Games Details

## Description
**DOD:**

- to create new endpoint (`GET: /api/v1/games/:id`)
- with no authentication
- with response
  - ```json
    ‌{
        "success": true,
        "message": "Success Get Game Details",
        "data": {
            "id": 1,
            "code": "RPS1",
            "title": "Rock-Paper-Scissors Random",
            "description": "Play Rock-Paper-Scissors with Computer (Organic Random)",
            "winnerPointsEarned": 5,
            "thumbnail": "https://google.com/image.jpg",
            "gameUrl": "{{baseURL}}/playing/:id",
            "viewCount": 0,
            "playCount": 0,
            "attributes": "{}"
        },
        "error": null
    }
    ```

**NOTE:** this endpoint will be hitted by FE whenever user/player Open Game Details for extracting Game Information


- Trello Link: [here](https://trello.com/c/rYaXT7Qs/19-beendpoint-add-new-endpoint-for-get-games-details)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor/Breaking Change
