### PR TITLE
[BE][DB] Add New Column Round in Games Table

### DIFF
--- a/db/migrations/20220828124810-add-number-of-rounds-on-games.js
+++ b/db/migrations/20220828124810-add-number-of-rounds-on-games.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('games', 'number_of_rounds', {
+      allowNull: false,
+      type: Sequelize.INTEGER,
+      defaultValue: 1,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('games', 'number_of_rounds');
+  },
+};

--- a/db/models/games.model.js
+++ b/db/models/games.model.js
@@ -63,6 +63,12 @@ module.exports = (sequelize, DataTypes) => {
         allowNull: true,
         type: DataTypes.TEXT,
       },
+      numberOfRounds: {
+        allowNull: false,
+        type: DataTypes.INTEGER,
+        defaultValue: 1,
+        field: 'number_of_rounds',
+      },
     },
     {
       sequelize,


### PR DESCRIPTION
## [BE][DB] Add New Column Round in Games Table

## Description
DoD
- need to add migration for new column `numberOfRounds` `int` , default value `1` , NOT NULL
- need to make sure the `numberOfRounds` also returned when calling game details endpoint

- Trello Link: [here](https://trello.com/c/EKjHx3W4/30-1-add-new-column-round-in-games-table)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor/Breaking Change
